### PR TITLE
Fix Uncaught TypeError

### DIFF
--- a/src/AutoKana.js
+++ b/src/AutoKana.js
@@ -195,7 +195,7 @@ export default class AutoKana {
         inputArray[i] = '';
       }
     }
-    return inputArray;
+    return inputArray.join('');
   }
 
   /**


### PR DESCRIPTION
# 現象

入力元のテキストフィールドの文字を1文字消すと `Uncaught TypeError` が発生します。

# 再現方法

- 入力元のテキストフィールドに文字を入力し、文字が漢字だけ（ひらがなを含まないように）になるように変換
- 入力文字を1文字消す

![8c922f0e4ceb174527af723c8c8397ae](https://user-images.githubusercontent.com/133594/39560056-c6c6221a-4ed5-11e8-8ae2-fa2cfdd918ac.gif)

# 変更内容

このケースの場合、 [removeString](https://github.com/ryo-utsunomiya/vanilla-autokana/blob/master/src/AutoKana.js#L187)  の戻り値が `Array` ( `[""]` )になってしまうため、 `String` が返るように変更しました。