### PR TITLE
Accept Element objets for AutoKana.bind arguments

### DIFF
--- a/__tests__/AutoKana.test.js
+++ b/__tests__/AutoKana.test.js
@@ -10,3 +10,15 @@ test('init', () => {
   autokana.start();
   expect(autokana.isActive).toBe(true);
 });
+
+test('init with pass elements', () => {
+  document.body.innerHTML = `
+<input name="name" id="name">
+<input name="furigana" id="furigana">
+`;
+  const name = document.getElementById('name')
+  const furigana = document.getElementById('furigana')
+  const autokana = new AutoKana(name, furigana);
+  autokana.start();
+  expect(autokana.isActive).toBe(true);
+});

--- a/__tests__/AutoKana.test.js
+++ b/__tests__/AutoKana.test.js
@@ -13,11 +13,11 @@ test('init', () => {
 
 test('init with pass elements', () => {
   document.body.innerHTML = `
-<input name="name" id="name">
-<input name="furigana" id="furigana">
+<input name="name">
+<input name="furigana">
 `;
-  const name = document.getElementById('name')
-  const furigana = document.getElementById('furigana')
+  const name = document.querySelector('[name=name]')
+  const furigana = document.querySelector('[name=furigana]')
   const autokana = new AutoKana(name, furigana);
   autokana.start();
   expect(autokana.isActive).toBe(true);

--- a/src/AutoKana.js
+++ b/src/AutoKana.js
@@ -20,6 +20,20 @@ function isHiragana(char) {
   return (c >= 12353 && c <= 12435) || c === 12445 || c === 12446;
 }
 
+function isString(val) {
+  return typeof val === 'string' || val instanceof String;
+}
+
+function ensureElement(idOrElement) {
+  if (isString(idOrElement)) {
+    return document.getElementById(ltrim(idOrElement, '#'));
+  }
+  if (idOrElement instanceof Element) {
+    return idOrElement;
+  }
+  return null;
+}
+
 // eslint-disable-next-line no-irregular-whitespace
 const kanaExtractionPattern = /[^ 　ぁあ-んー]/g;
 const kanaCompactingPattern = /[ぁぃぅぇぉっゃゅょ]/g;
@@ -44,8 +58,8 @@ export default class AutoKana {
       option,
     );
 
-    const elName = document.getElementById(ltrim(name, '#'));
-    const elFurigana = document.getElementById(ltrim(furigana, '#'));
+    const elName = ensureElement(name);
+    const elFurigana = ensureElement(furigana);
 
     if (!elName) throw new Error(`Element not found: ${name}`);
 

--- a/types/autokana.d.ts
+++ b/types/autokana.d.ts
@@ -1,16 +1,17 @@
 declare module 'vanilla-autokana' {
+  type Bindable = string | Element
   export interface Option {
     katakana: boolean;
     debug: boolean;
     checkInterval: number;
   }
   export function bind(
-    name: string,
-    furigana?: string,
+    name: Bindable,
+    furigana?: Bindable,
     option?: Partial<Option>,
   ): AutoKana;
   class AutoKana {
-    constructor(name: string, furigana?: string, option?: Partial<Option>);
+    constructor(name: Bindable, furigana?: Bindable, option?: Partial<Option>);
     public getFurigana(): string;
     public start(): void;
     public stop(): void;


### PR DESCRIPTION
`AutoKana.bind` に要素の id ではなく Element オブジェクトを直接渡せるようにしました。
この修正により、AutoKana を id がない要素にも使えるようになります。